### PR TITLE
Add Balatro HQ to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Collect all Balatro mods and tools, welcome to add!
 ## Tools
 
 - [Balatro Calculator](https://efhiii.github.io/balatro-calculator/) - Calculate the best score for any Balatro hand. by [@Saffron](https://github.com/efhiii)
+- [Balatro HQ](https://balatrohq.com/) - Web tools for Balatro: a score calculator with side-by-side build comparison, a free seed analyzer with AI playstyle advice, and a seed vault that saves seeds with their build summary and notes. by [@o98k-ok](https://github.com/o98k-ok)
 - [Balatro Mobile Maker](https://github.com/blake502/balatro-mobile-maker) - Create a mobile Balatro app from your Steam version of Balatro. by [@blake502](https://github.com/blake502)
 - [Balatro Modpack Manager](https://github.com/Dimserene/Balatro-ModpackManager) - Install, update, and customize modpacks in one streamlined tool. by [@Dimserene]
 - [Balatro Seed Oracle](https://github.com/OptimusPi/BalatroSeedOracle) - Balatro Seed Searcher with visual drag&drop filter builder coded in C# and AvaloniaUI. by [@OptimusPi](https://github.com/OptimusPi)


### PR DESCRIPTION
Adds Balatro HQ to the Tools section.

A web tool set for Balatro, with three main features:
- a score calculator that compares two builds side by side
- a free seed analyzer that replays the game's real RNG, with AI playstyle advice
- a seed vault to save seeds with their build summary and notes

Placed alphabetically between Balatro Calculator and Balatro Mobile Maker. A companion PR adds the same entry to README-zh_CN.md on the Chinese branch.
